### PR TITLE
test-helper.el requires s.el

### DIFF
--- a/Cask
+++ b/Cask
@@ -9,4 +9,5 @@
 (depends-on "shut-up")
 
 (development
-  (depends-on "ert-runner"))
+  (depends-on "ert-runner")
+  (depends-on "s"))

--- a/test/test-helper.el
+++ b/test/test-helper.el
@@ -9,6 +9,7 @@
 ;; Test suite setup for ERT Runner.
 
 (require 'undercover)
+(require 's)
 
 ;;; Code:
 


### PR DESCRIPTION
test-helper.el tries to use a function from `s.el`.  This patch `require`s `s.el` and notes the dependency in the `Cask` file.