### PR TITLE
Improve package description

### DIFF
--- a/undercover.el
+++ b/undercover.el
@@ -1,4 +1,4 @@
-;;; undercover.el --- Test coverage library for Emacs -*- lexical-binding: t -*-
+;;; undercover.el --- Test coverage library for Emacs Lisp -*- lexical-binding: t -*-
 
 ;; Copyright (c) 2014 Sviridov Alexander
 


### PR DESCRIPTION
"for Emacs" is usually redundant, including in this case, but "for Emacs Lisp" is descriptive and helpful.